### PR TITLE
Fix typo in the R-package (removal of column names)

### DIFF
--- a/r-package/rtk/R/rarefaction.R
+++ b/r-package/rtk/R/rarefaction.R
@@ -94,7 +94,7 @@ rtk <- function(input, repeats = 10, depth = 0, ReturnMatrix = 0, margin = 2, ve
   }
     result <- lapply(result, function(res){
         # remove names, if there werent any
-        if(removeRnames == TRUE && removeRnames == TRUE){
+        if(removeRnames == TRUE && removeCnames == TRUE){
           res$raremat <- lapply(res$raremat, unname)
         }else{
           if(removeRnames == TRUE){


### PR DESCRIPTION
Hello!
I think there is a small noncritical typo in the `rtk` function in the R-package with the removal of auto-assigned column names. The same condition was tested twice:
`removeRnames == TRUE && removeRnames == TRUE`
should be
`removeRnames == TRUE && removeCnames == TRUE`

Thanks for the great software, I find it very useful!
With best regards,
Vladimir