### PR TITLE
checking for return value to handle wunsued warning

### DIFF
--- a/rtk/ClStr2Mat.cpp
+++ b/rtk/ClStr2Mat.cpp
@@ -9,10 +9,10 @@ textBlock* getClusBlock(FILE* incl,string& lastline) {//istream& incl
 		ret->txt.push_back(lastline);
 	} else {
 		//getline(incl, line);
-		fgets(buf, sizeof buf, incl);
-		buf[strcspn(buf, "\n")] = 0;
-
-		ret->txt.push_back(string(buf));
+		if(fgets(buf, sizeof buf, incl) != NULL){
+			buf[strcspn(buf, "\n")] = 0;
+			ret->txt.push_back(string(buf));
+        }
 	}
 	while (fgets(buf, sizeof buf, incl) != NULL) {
 		buf[strcspn(buf, "\n")] = 0;


### PR DESCRIPTION
Currently the rtk package can not be used with the r-devel version of R as of this error:

```  
ClStr2Mat.cpp:12:3: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
```
https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/rtk-00check.html

Obviously we are asked to handle the return value of `fgets`. This commit is a suggestion for this. As I did not write this code it would be best if @hildebra could sign of on this change.