### PR TITLE
linking of zlib for RTK binary

### DIFF
--- a/rtk/Makefile
+++ b/rtk/Makefile
@@ -10,7 +10,7 @@ program_INCLUDE_DIRS :=
 program_LIBRARY_DIRS :=
 program_LIBRARIES :=
 
-CPPFLAGS += -std=c++0x -lz -Wall -O3 -D__USE_XOPEN2K8 -DnotRpackage=1
+CPPFLAGS += -std=c++0x -lz  -Wall -O3 -D__USE_XOPEN2K8 -DnotRpackage=1
 CPPFLAGS += $(foreach includedir,$(program_INCLUDE_DIRS),-I$(includedir))
 LDFLAGS += -pthread $(foreach librarydir,$(program_LIBRARY_DIRS),-L$(librarydir))
 LDFLAGS += $(foreach library,$(program_LIBRARIES),-l$(library))
@@ -20,7 +20,7 @@ LDFLAGS += $(foreach library,$(program_LIBRARIES),-l$(library))
 all: $(program_NAME)
 
 $(program_NAME): $(program_OBJS)
-	$(LINK.cc) $(program_OBJS) -o $(program_NAME)
+	$(LINK.cc) $(program_OBJS) -o $(program_NAME) -lz
 
 clean:
 	@- $(RM) $(program_NAME)


### PR DESCRIPTION
With the current make file I was not able to build the rtk binary under debian. I do get the error:
```
/usr/bin/ld: IO.o: in function `lineCntOut(options*)':
IO.cpp:(.text+0x5905): undefined reference to `gzopen'
/usr/bin/ld: IO.o: in function `gzstreambuf::sync()':
IO.cpp:(.text._ZN11gzstreambuf4syncEv[_ZN11gzstreambuf4syncEv]+0x33): undefined reference to `gzwrite'
/usr/bin/ld: IO.o: in function `gzstreambuf::underflow()':
IO.cpp:(.text._ZN11gzstreambuf9underflowEv[_ZN11gzstreambuf9underflowEv]+0x88): undefined reference to `gzread'
/usr/bin/ld: IO.o: in function `gzstreambuf::overflow(int)':

...
```

Indicating the zlib library was not correctly linked. I suggest this fix, but even with this fix I was not able to rarefy gzipped or zipped tables. Thus it might be wrongly linked still for me. 
Any suggestions?