### PR TITLE
Sample order

### DIFF
--- a/r-package/rtk/R/rarefaction.R
+++ b/r-package/rtk/R/rarefaction.R
@@ -92,7 +92,20 @@ rtk <- function(input, repeats = 10, depth = 1000, ReturnMatrix = 0, margin = 2,
   }else{
     stop("Unknown input type. Path to a file (character) or a numeric matrix are accepted types.")
   }
-    result <- lapply(result, function(res){
+    result <- lapply(result, function(res) {
+        # Parallel processing can cause rarefied matrices to have different
+        # column or row ordering than input. Rearrange to input order if
+        # number of threads > 1
+        if (threads > 1) {
+          res$raremat <- lapply(res$raremat, \(mat) {
+            # Some rows or columns could be dropped, so take subset which is 
+            # shared
+            cols <- colnames(input)[colnames(input) %in% colnames(mat)]
+            rows <- rownames(input)[rownames(input) %in% rownames(mat)]
+            return(mat[rows, cols])
+          })
+        }
+
         # remove names, if there werent any
         if(removeRnames == TRUE && removeCnames == TRUE){
           res$raremat <- lapply(res$raremat, unname)
@@ -104,7 +117,6 @@ rtk <- function(input, repeats = 10, depth = 1000, ReturnMatrix = 0, margin = 2,
             res$raremat <- lapply(res$raremat, function(x) {colnames(x) <- NULL; return (x)})
           }
         }
-            
         
 
         if(length(res$skipped) > 0){

--- a/r-package/rtk/tests/testthat/test_rare.R
+++ b/r-package/rtk/tests/testthat/test_rare.R
@@ -53,11 +53,41 @@ test_that("rare has the right names", {
 })
 
 
-test_that("diversity has the right names", {
+test_that("divvs has right names", {
   # Single thread
+  data <- matrix(seq(from = 1, to = 100), 10)
+  cnames <- paste(rep("TestColNames"), 1:ncol(data))
+  rnames <- paste(rep("TestRowNames"), 1:nrow(data))
+  colnames(data) <- cnames
+  rownames(data) <- rnames
 
-  # Parallel
+  # Single thread cases
+  res <- rtk(data, depth = min(colSums(data)), ReturnMatrix = 1, margin = 2,
+             verbose = FALSE)
+  expect_equal(
+    lapply(res$divvs, \(x) {x$samplename}) |> unlist(),
+    cnames
+  )
+  res <- rtk(data, depth = min(colSums(data)), ReturnMatrix = 1, margin = 1,
+             verbose = FALSE)
+  expect_equal(
+    lapply(res$divvs, \(x) {x$samplename}) |> unlist(),
+    rnames
+  )
 
+  # Multithread cases
+  res <- rtk(data, depth = min(colSums(data)), ReturnMatrix = 1, margin = 2,
+             verbose = FALSE, threads = 4)
+  expect_equal(
+    lapply(res$divvs, \(x) {x$samplename}) |> unlist(),
+    cnames
+  )
+  res <- rtk(data, depth = min(colSums(data)), ReturnMatrix = 1, margin = 1,
+             verbose = FALSE, threads = 4)
+  expect_equal(
+    lapply(res$divvs, \(x) {x$samplename}) |> unlist(),
+    rnames
+  )
 })
 
 

--- a/r-package/rtk/tests/testthat/test_rare.R
+++ b/r-package/rtk/tests/testthat/test_rare.R
@@ -24,6 +24,40 @@ test_that("rare has the right names", {
 
   expect_equal(colnames(rtk(data, depth=min(rowSums(data)), ReturnMatrix = 1, margin = 1, verbose=F)$raremat[[1]]), cnames)
   expect_equal(rownames(rtk(data, depth=min(rowSums(data)), ReturnMatrix = 1, margin = 1, verbose=F)$raremat[[1]]), rnames)
+
+  # Test rare has the right names when run with multiple threads
+  # If column / row order is truly random, there is still a small chance this
+  # test passes by randomly coming back in the right order. Could consider
+  # running multiple times if this is a consistent issue.
+  expect_equal(colnames(rtk(data, depth=min(colSums(data)), ReturnMatrix = 1, margin = 2, verbose=F, threads=4)$raremat[[1]]), cnames)
+  expect_equal(rownames(rtk(data, depth=min(rowSums(data)), ReturnMatrix = 1, margin = 2, verbose=F, threads=4)$raremat[[1]]), rnames)
+
+  expect_equal(colnames(rtk(data, depth=min(rowSums(data)), ReturnMatrix = 1, margin = 1, verbose=F, threads=4)$raremat[[1]]), cnames)
+  expect_equal(rownames(rtk(data, depth=min(rowSums(data)), ReturnMatrix = 1, margin = 1, verbose=F, threads=4)$raremat[[1]]), rnames)
+
+  # Test name order is consistent within rarefaction matrices from the same call
+  rare_mats <- rtk(data, depth=min(colSums(data)), ReturnMatrix = 5, margin = 2, verbose=F, threads=4, repeats=5)$raremat
+  for (i in seq(1, length(rare_mats) - 1)) {
+    for (j in seq(i + 1, length(rare_mats))) {
+      expect_equal(colnames(rare_mats[[i]]), colnames(rare_mats[[j]]))
+      expect_equal(rownames(rare_mats[[i]]), rownames(rare_mats[[j]]))
+    }
+  }
+  rare_mats <- rtk(data, depth=min(rowSums(data)), ReturnMatrix = 5, margin = 1, verbose=F, threads=4, repeats=5)$raremat
+  for (i in seq(1, length(rare_mats) - 1)) {
+    for (j in seq(i + 1, length(rare_mats))) {
+      expect_equal(colnames(rare_mats[[i]]), colnames(rare_mats[[j]]))
+      expect_equal(rownames(rare_mats[[i]]), rownames(rare_mats[[j]]))
+    }
+  }
+})
+
+
+test_that("diversity has the right names", {
+  # Single thread
+
+  # Parallel
+
 })
 
 


### PR DESCRIPTION
When running with multiple threads, the raremats returned could be in a different order to the input, and to the order of divvs. I've added a reordering step in the R package, along with corresponding unit tests. Added a unit test for divv ordering as well, just to make sure that was being maintained. All tests are passing.